### PR TITLE
ci: improve CI/CD to match GraphForge comprehensiveness

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,6 +10,18 @@ models:
   - changed-files:
     - any-glob-to-any-file: "src/infoextract_cidoc/models/**"
 
+validators:
+  - changed-files:
+    - any-glob-to-any-file: "src/infoextract_cidoc/validators/**"
+
+codegen:
+  - changed-files:
+    - any-glob-to-any-file: "src/infoextract_cidoc/codegen/**"
+
+visualization:
+  - changed-files:
+    - any-glob-to-any-file: "src/infoextract_cidoc/visualization/**"
+
 tests:
   - changed-files:
     - any-glob-to-any-file: "src/infoextract_cidoc/tests/**"

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -3,9 +3,11 @@ name: Changelog Check
 on:
   pull_request:
     branches: ["main"]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   check:
+    name: Verify CHANGELOG Updated
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
     steps:
@@ -13,12 +15,79 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check CHANGELOG updated
+      - name: Check for bypass labels
+        id: check_labels
         run: |
-          if git diff --name-only origin/main...HEAD | grep -q "CHANGELOG.md"; then
-            echo "CHANGELOG.md was updated."
+          SKIP=$(gh pr view ${{ github.event.pull_request.number }} \
+            --json labels --jq '.labels[].name' | grep -c "skip-changelog" || echo "0")
+          NONE=$(gh pr view ${{ github.event.pull_request.number }} \
+            --json labels --jq '.labels[].name' | grep -c "release:none" || echo "0")
+          echo "skip=$SKIP" >> $GITHUB_OUTPUT
+          echo "release_none=$NONE" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check CHANGELOG.md changes
+        id: check_changelog
+        run: |
+          BASE_SHA=${{ github.event.pull_request.base.sha }}
+          MODIFIED=$(git diff --name-only "$BASE_SHA"..HEAD | grep -c "CHANGELOG.md" || echo "0")
+          echo "modified=$MODIFIED" >> $GITHUB_OUTPUT
+          if [ "$MODIFIED" = "1" ]; then
+            ENTRIES=$(git diff "$BASE_SHA"..HEAD -- CHANGELOG.md | grep -c "^+.*- " || echo "0")
+            echo "entries=$ENTRIES" >> $GITHUB_OUTPUT
           else
-            echo "ERROR: CHANGELOG.md was not updated in this PR."
-            echo "Please add an entry under [Unreleased] in CHANGELOG.md."
-            exit 1
+            echo "entries=0" >> $GITHUB_OUTPUT
           fi
+
+      - name: Determine result
+        id: result
+        run: |
+          if [ "${{ steps.check_labels.outputs.skip }}" = "1" ] || \
+             [ "${{ steps.check_labels.outputs.release_none }}" = "1" ]; then
+            echo "pass=true" >> $GITHUB_OUTPUT
+            echo "reason=PR has bypass label (skip-changelog or release:none)" >> $GITHUB_OUTPUT
+          elif [ "${{ steps.check_changelog.outputs.modified }}" = "1" ] && \
+               [ "${{ steps.check_changelog.outputs.entries }}" -gt "0" ]; then
+            echo "pass=true" >> $GITHUB_OUTPUT
+            echo "reason=CHANGELOG [Unreleased] section was updated" >> $GITHUB_OUTPUT
+          else
+            echo "pass=false" >> $GITHUB_OUTPUT
+            if [ "${{ steps.check_changelog.outputs.modified }}" = "0" ]; then
+              echo "reason=CHANGELOG.md was not modified" >> $GITHUB_OUTPUT
+            else
+              echo "reason=CHANGELOG.md modified but [Unreleased] section appears unchanged" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      - name: Post failure comment
+        if: steps.result.outputs.pass == 'false'
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body \
+          "## CHANGELOG Check Failed
+
+          **Reason:** ${{ steps.result.outputs.reason }}
+
+          Add your changes to the \`[Unreleased]\` section in \`CHANGELOG.md\`:
+          \`\`\`markdown
+          ## [Unreleased]
+
+          ### Added / Fixed / Changed
+          - Your change here
+          \`\`\`
+
+          Or add a label to bypass:
+          - \`skip-changelog\` — exceptional cases
+          - \`release:none\` — docs/CI-only changes that do not warrant a release entry"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fail if check did not pass
+        if: steps.result.outputs.pass == 'false'
+        run: |
+          echo "CHANGELOG check failed: ${{ steps.result.outputs.reason }}"
+          exit 1
+
+      - name: Success
+        if: steps.result.outputs.pass == 'true'
+        run: echo "CHANGELOG check passed: ${{ steps.result.outputs.reason }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,15 @@ name: Docs
 on:
   push:
     branches: ["main"]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
   workflow_dispatch:
 
 permissions:
@@ -16,32 +25,33 @@ concurrency:
 
 jobs:
   build:
+    name: Build Documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
         with:
-          version: "latest"
-
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
       - name: Install dependencies
         run: uv sync --group docs
-
       - name: Build docs
         run: uv run mkdocs build --strict
-
       - name: Upload pages artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v4
         with:
           path: site/
 
   deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/llm-tests.yml
+++ b/.github/workflows/llm-tests.yml
@@ -8,31 +8,15 @@ on:
 jobs:
   llm-tests:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v7
         with:
-          version: "latest"
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+          enable-cache: true
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-
-      - name: Cache uv dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: ${{ runner.os }}-uv-${{ hashFiles('**/uv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-uv-
-
-      - name: Install dependencies
-        run: uv sync
-
+      - run: uv sync
       - name: Run LLM tests
         run: uv run pytest src/infoextract_cidoc/tests/ -m llm -v
         env:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -5,13 +5,78 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
   label:
+    name: Apply File Labels
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v6
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true
+
+  release-none:
+    name: Auto release:none for docs/CI PRs
+    runs-on: ubuntu-latest
+    needs: label
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect docs/CI-only PR
+        id: detect
+        run: |
+          BASE_SHA=${{ github.event.pull_request.base.sha }}
+          FILES=$(git diff --name-only "$BASE_SHA"..HEAD)
+
+          HAS_SRC=0
+          HAS_DOCS=0
+          HAS_CI=0
+
+          while IFS= read -r file; do
+            case "$file" in
+              src/infoextract_cidoc/tests/*) ;;          # tests don't count as src
+              src/*) HAS_SRC=1 ;;
+              docs/*.md|docs/**|*.md|mkdocs.yml) HAS_DOCS=1 ;;
+              .github/*) HAS_CI=1 ;;
+            esac
+          done <<< "$FILES"
+
+          RELEASE_NONE=0
+          if [ "$HAS_SRC" = "0" ] && { [ "$HAS_DOCS" = "1" ] || [ "$HAS_CI" = "1" ]; }; then
+            RELEASE_NONE=1
+          fi
+
+          echo "release_none=$RELEASE_NONE" >> $GITHUB_OUTPUT
+
+      - name: Ensure release:none label exists
+        if: steps.detect.outputs.release_none == '1'
+        run: |
+          gh label create "release:none" \
+            --color "e4e669" \
+            --description "Docs/CI-only — no release entry needed" \
+            --force
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply release:none label
+        if: steps.detect.outputs.release_none == '1'
+        run: gh pr edit ${{ github.event.pull_request.number }} --add-label "release:none"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post label summary (on open only)
+        if: github.event.action == 'opened'
+        run: |
+          LABELS=$(gh pr view ${{ github.event.pull_request.number }} \
+            --json labels --jq '[.labels[].name] | join(", ")')
+          if [ -n "$LABELS" ]; then
+            gh pr comment ${{ github.event.pull_request.number }} \
+              --body "Labels applied: \`$LABELS\`"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-tracking.yml
+++ b/.github/workflows/release-tracking.yml
@@ -1,24 +1,143 @@
-name: Release Readiness
+name: Release Tracking
 
 on:
+  pull_request:
+    types: [closed]
+  release:
+    types: [published]
   schedule:
     - cron: "0 9 * * 1"  # Every Monday at 9am UTC
   workflow_dispatch:
 
 jobs:
-  check:
+  label-merged-pr:
+    name: Label Merged PRs
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Ensure release:pending label exists
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'release:patch') ||
+          contains(github.event.pull_request.labels.*.name, 'release:minor') ||
+          contains(github.event.pull_request.labels.*.name, 'release:major')
+        run: |
+          gh label create "release:pending" \
+            --color "0075ca" \
+            --description "Merged — waiting for release" \
+            --force
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add release:pending label
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'release:patch') ||
+          contains(github.event.pull_request.labels.*.name, 'release:minor') ||
+          contains(github.event.pull_request.labels.*.name, 'release:major')
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --add-label "release:pending" \
+            --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  check-release-needed:
+    name: Check if Release Needed
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
         with:
-          version: "latest"
+          fetch-depth: 0
 
-      - name: Install dependencies
-        run: uv sync
+      - name: Check for unreleased changes
+        id: check
+        run: |
+          # Count merged PRs with release:pending label
+          PENDING=$(gh pr list \
+            --base main \
+            --state merged \
+            --label "release:pending" \
+            --json number \
+            --jq 'length' || echo "0")
+          echo "pending=$PENDING" >> $GITHUB_OUTPUT
 
-      - name: Check release readiness
-        run: uv run python scripts/check_release_needed.py
-        continue-on-error: true
+          # Count entries in [Unreleased] CHANGELOG section
+          UNRELEASED=$(awk \
+            '/## \[Unreleased\]/{found=1; next} /## \[/{if(found) exit} found && /^###/{print}' \
+            CHANGELOG.md | wc -l | xargs)
+          echo "unreleased=$UNRELEASED" >> $GITHUB_OUTPUT
+
+          echo "Pending release PRs: $PENDING"
+          echo "Unreleased CHANGELOG sections: $UNRELEASED"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create reminder issue if needed
+        run: |
+          PENDING=${{ steps.check.outputs.pending }}
+          UNRELEASED=${{ steps.check.outputs.unreleased }}
+
+          if [ "$PENDING" -gt "0" ] || [ "$UNRELEASED" -gt "0" ]; then
+            # Skip if reminder issue already open
+            EXISTING=$(gh issue list \
+              --label "release:reminder" \
+              --state open \
+              --json number \
+              --jq '.[0].number')
+
+            if [ -z "$EXISTING" ]; then
+              gh label create "release:reminder" \
+                --color "e11d48" \
+                --description "Automated release reminder" \
+                --force
+              gh issue create \
+                --title "Release Reminder: Unreleased changes on main" \
+                --label "release:reminder" \
+                --body "## Release Status
+
+          The weekly release check found unreleased changes.
+
+          - **Merged PRs with \`release:pending\`:** $PENDING
+          - **CHANGELOG \`[Unreleased]\` sections:** $UNRELEASED
+
+          ### Next steps
+          1. Review \`CHANGELOG.md\` \`[Unreleased]\` section
+          2. Check pending PRs: \`gh pr list --state merged --label 'release:pending'\`
+          3. Create a release via GitHub Releases when ready
+
+          ---
+          *Auto-created by release tracking workflow. Close when a release is published.*"
+              echo "Created release reminder issue"
+            else
+              echo "Reminder issue #$EXISTING already open — skipping"
+            fi
+          else
+            echo "No unreleased changes — no reminder needed"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  close-reminder-on-release:
+    name: Close Reminder on Release
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Close open reminder issues
+        run: |
+          gh issue list \
+            --label "release:reminder" \
+            --state open \
+            --json number \
+            --jq '.[].number' | while read -r issue; do
+            gh issue close "$issue" \
+              --comment "Closing: release ${{ github.event.release.tag_name }} published."
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Test Suite
 
 on:
   push:
@@ -7,58 +7,120 @@ on:
     branches: ["main"]
 
 jobs:
-  test:
+  lint:
+    name: Lint and Format
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.13"]
-
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v7
         with:
-          version: "latest"
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+          enable-cache: true
+      - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Cache uv dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/uv
-          key: ${{ runner.os }}-uv-${{ hashFiles('**/uv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-uv-
-
-      - name: Install dependencies
-        run: uv sync
-
+          python-version: "3.13"
+      - run: uv sync
       - name: Format check
         run: uv run ruff format --check src/
-
       - name: Lint
         run: uv run ruff check src/
 
-      - name: Type check
-        run: uv run mypy src/infoextract_cidoc/
-        continue-on-error: true
-
-      - name: Security check
-        run: uv run bandit -c pyproject.toml -r src/infoextract_cidoc/
-        continue-on-error: true
-
-      - name: Run tests with coverage
-        run: uv run pytest src/infoextract_cidoc/tests/ -m "not llm" --cov=src/infoextract_cidoc --cov-report=xml -v
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
-          file: coverage.xml
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - run: uv sync
+      - name: Run mypy
+        run: uv run mypy src/infoextract_cidoc/
+
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - run: uv sync
+      - name: Run bandit
+        run: uv run bandit -c pyproject.toml -r src/infoextract_cidoc/
+
+  test:
+    name: Test (${{ matrix.os }} / Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.13"]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync
+      - name: Run tests
+        run: uv run pytest src/infoextract_cidoc/tests/ -m "not llm" -n auto --junitxml=test-results.xml -v
+      - name: Upload test results to Codecov
+        uses: codecov/codecov-action@v5
+        if: always()
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: test-results.xml
+          flags: ${{ matrix.os }}-py${{ matrix.python-version }}
+          report_type: test_results
           fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - run: uv sync
+      - name: Run tests with coverage
+        run: >
+          uv run pytest src/infoextract_cidoc/tests/ -m "not llm" -n auto
+          --cov=src/infoextract_cidoc --cov-branch
+          --cov-report=xml --cov-report=html --cov-report=term
+          --cov-fail-under=70
+          --junitxml=test-results.xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: coverage
+          name: codecov-coverage
+          fail_ci_if_error: false
+      - name: Upload test results to Codecov
+        uses: codecov/codecov-action@v5
+        if: always()
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: test-results.xml
+          flags: coverage-suite
+          report_type: test_results
+          fail_ci_if_error: false
+      - name: Upload coverage HTML artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: htmlcov/


### PR DESCRIPTION
Closes #10.

## Summary

- **`test.yml`** — split into 5 parallel jobs: `lint`, `type-check`, `security`, `test`, `coverage`; mypy and bandit are now hard failures; test matrix runs Ubuntu/macOS/Windows; JUnit XML uploaded to Codecov test results; coverage HTML artifact uploaded per run
- **`changelog-check.yml`** — adds `skip-changelog`/`release:none` label bypass; posts a fix-instructions comment on failure; validates `[Unreleased]` section content, not just file modification
- **`pr-labeler.yml`** — adds second job to auto-apply `release:none` for docs/CI-only PRs; posts label summary comment on open
- **`release-tracking.yml`** — replaces broken `check_release_needed.py` call with self-contained logic; adds `label-merged-pr` job, weekly reminder issue creation, and auto-close on release publish
- **`docs.yml`** — triggers build validation on PRs touching docs; gates artifact upload and deploy on non-PR events
- **`llm-tests.yml`** — removes manual cache step (replaced by `enable-cache: true`); bumps `setup-python` to v6
- **`labeler.yml`** — adds `validators`, `codegen`, `visualization` module labels

## Test plan

- [ ] `lint` / `type-check` / `security` jobs run in parallel and are hard failures
- [ ] `test` matrix shows 3 runs (ubuntu/macos/windows)
- [ ] `coverage` job uploads HTML artifact and enforces 70% threshold
- [ ] Changelog check passes on PRs with `release:none` label
- [ ] Changelog check posts comment on failure
- [ ] `release-none` job auto-labels docs/CI-only PRs
- [ ] Release tracking weekly job creates reminder issue when unreleased changes exist

🤖 Generated with [Claude Code](https://claude.ai/claude-code)