### PR TITLE
fix: guard changelog-check against non-PR events and update description

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -9,7 +9,7 @@ jobs:
   check:
     name: Verify CHANGELOG Updated
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Changelog check no longer fires on direct pushes to main (added `github.event_name == 'pull_request'` guard)
+
+### Changed
+- Updated project description in `pyproject.toml` to accurately reflect the toolkit's capabilities
+- Updated Python version badge in README from 3.13+ to 3.12+
+
 ## [0.1.2] - 2026-02-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Classful Ontology for Life-Events Information Extraction**
 
-[![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Code style: ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Tests](https://img.shields.io/badge/tests-pytest-blue.svg)](https://pytest.org/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "infoextract-cidoc"
 version = "0.1.2"
-description = "Classful Ontology for Life-Events Information Extraction"
+description = "LLM-powered CIDOC CRM v7.1.3 entity extraction from unstructured text — Pydantic models, Cypher emitters, and NetworkX integration"
 readme = "README.md"
 requires-python = ">=3.12"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- **Changelog check fix**: added `github.event_name == 'pull_request'` condition to the job — was firing on direct pushes to main (e.g. version bump commits) because the `labeled` event can fire after a merge; the guard ensures the job is a no-op on any non-PR event
- **Project description**: updated `pyproject.toml` description from stale `"Classful Ontology for Life-Events Information Extraction"` to `"LLM-powered CIDOC CRM v7.1.3 entity extraction from unstructured text — Pydantic models, Cypher emitters, and NetworkX integration"`
- **README badge**: updated Python version badge from `3.13+` to `3.12+`

## Test plan

- [ ] All CI checks pass
- [ ] After merge, direct push to main does not trigger a changelog-check run

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed changelog check to only run on pull requests, preventing execution on direct pushes.

* **Chores**
  * Updated Python version support from 3.13+ to 3.12+.
  * Updated project description to reflect toolkit capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->