### PR TITLE
fix: correct YAML parse error in changelog-check workflow

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -90,4 +90,5 @@ jobs:
 
       - name: Success
         if: steps.result.outputs.pass == 'true'
-        run: echo "CHANGELOG check passed: ${{ steps.result.outputs.reason }}"
+        run: |
+          echo "CHANGELOG check passed: ${{ steps.result.outputs.reason }}"

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -19,9 +19,9 @@ jobs:
         id: check_labels
         run: |
           SKIP=$(gh pr view ${{ github.event.pull_request.number }} \
-            --json labels --jq '.labels[].name' | grep -c "skip-changelog" || echo "0")
+            --json labels --jq '.labels[].name' | grep -c "skip-changelog" || true)
           NONE=$(gh pr view ${{ github.event.pull_request.number }} \
-            --json labels --jq '.labels[].name' | grep -c "release:none" || echo "0")
+            --json labels --jq '.labels[].name' | grep -c "release:none" || true)
           echo "skip=$SKIP" >> $GITHUB_OUTPUT
           echo "release_none=$NONE" >> $GITHUB_OUTPUT
         env:
@@ -31,10 +31,10 @@ jobs:
         id: check_changelog
         run: |
           BASE_SHA=${{ github.event.pull_request.base.sha }}
-          MODIFIED=$(git diff --name-only "$BASE_SHA"..HEAD | grep -c "CHANGELOG.md" || echo "0")
+          MODIFIED=$(git diff --name-only "$BASE_SHA"..HEAD | grep -c "CHANGELOG.md" || true)
           echo "modified=$MODIFIED" >> $GITHUB_OUTPUT
           if [ "$MODIFIED" = "1" ]; then
-            ENTRIES=$(git diff "$BASE_SHA"..HEAD -- CHANGELOG.md | grep -c "^+.*- " || echo "0")
+            ENTRIES=$(git diff "$BASE_SHA"..HEAD -- CHANGELOG.md | grep -c "^+.*- " || true)
             echo "entries=$ENTRIES" >> $GITHUB_OUTPUT
           else
             echo "entries=0" >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-02-26
+
+### Fixed
+- Fixed YAML parse error in `changelog-check.yml` — colon-space inside unquoted `run:` scalar now uses block scalar (`|`)
+
 ## [0.1.3] - 2026-02-26
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infoextract-cidoc"
-version = "0.1.3"
+version = "0.1.4"
 description = "LLM-powered CIDOC CRM v7.1.3 entity extraction from unstructured text — Pydantic models, Cypher emitters, and NetworkX integration"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- Fix YAML parse error in `.github/workflows/changelog-check.yml` — the `run: echo "... passed: ..."` plain scalar contained a colon-space which is forbidden in YAML and caused GitHub to reject the workflow file
- Bump version to 0.1.4 and update CHANGELOG

## Root cause
`run: echo "CHANGELOG check passed: ${{ ... }}"` — the `: ` after `passed` is a YAML mapping indicator, making the plain scalar invalid. GitHub reported the workflow as a "workflow file issue" with 0s duration.

## Fix
Convert to a block scalar:
```yaml
run: |
  echo "CHANGELOG check passed: ${{ steps.result.outputs.reason }}"
```

## Test plan
- [ ] CI passes (changelog-check no longer shows "workflow file issue")
- [ ] Direct push to main does not trigger changelog-check job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a YAML parsing issue affecting changelog validation.

* **Documentation**
  * Added an Unreleased changelog entry (0.1.4) noting the fix.

* **Chores**
  * Bumped project version to 0.1.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->